### PR TITLE
[feature] Enforce Discord guild membership for players

### DIFF
--- a/src/main/java/net/justempire/discordverificator/discord/DiscordBot.java
+++ b/src/main/java/net/justempire/discordverificator/discord/DiscordBot.java
@@ -3,6 +3,8 @@ package net.justempire.discordverificator.discord;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -62,9 +64,44 @@ public class DiscordBot extends ListenerAdapter {
 
     public boolean isBotEnabled() { return botEnabled; }
 
+    /**
+     * Checks whether the user is on the specified Discord server.
+     * This method makes an API request to Discord, so it is blocking (use only in asynchronous events).
+     * @param discordId The Discord ID of the user to check
+     * @param guildId The ID of the Discord server to check against
+     * @return true if the user is on the server, false otherwise
+     */
+    public boolean isUserInGuild(String discordId, String guildId) {
+        if (plugin.getJDA() == null) return true;
+
+        Guild guild = plugin.getJDA().getGuildById(guildId);
+        if (guild == null) {
+            logger.warning("Unable to find the Discord server (Guild) with ID " + guildId + ". Is the bot on the server?");
+            return true;
+        }
+
+        // Verifies user membership in guild via API; returns true on errors
+        try {
+            if (guild.getMemberById(discordId) != null) return true;
+
+            Member member = guild.retrieveMemberById(discordId).complete();
+            return member != null;
+        } catch (net.dv8tion.jda.api.exceptions.ErrorResponseException e) {
+            if (e.getErrorResponse() == net.dv8tion.jda.api.requests.ErrorResponse.UNKNOWN_MEMBER ||
+                    e.getErrorResponse() == net.dv8tion.jda.api.requests.ErrorResponse.UNKNOWN_USER) {
+                return false;
+            }
+            logger.log(Level.WARNING, "API error when checking if a player is on the Discord server", e);
+            return true;
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "An unexpected error occurred while checking if a player is on the Discord server", e);
+            return true;
+        }
+    }
+
     @Override
     public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
-        // If command is "confirm"
+        // If the command is "confirm"
         if (event.getName().equals("confirm")) onConfirmSlashCommand(event);
     }
 

--- a/src/main/java/net/justempire/discordverificator/listeners/JoinListener.java
+++ b/src/main/java/net/justempire/discordverificator/listeners/JoinListener.java
@@ -62,6 +62,19 @@ public class JoinListener implements Listener {
             return;
         }
 
+        // --- CHECKING ATTENDANCE ON THE DISCORD SERVER ---
+        String requiredGuildId = plugin.getConfig().getString("required-guild-id");
+        // Enforces required Discord guild membership before login
+        if (requiredGuildId != null && !requiredGuildId.isEmpty()) {
+            boolean isInGuild = plugin.getDiscordBot().isUserInGuild(discordId, requiredGuildId);
+            if (!isInGuild) {
+                String inviteLink = plugin.getConfig().getString("discord-invite-link", "https://discord.gg/");
+                String kickMessage = String.format(getMessage("in-game.not-in-discord-server"), inviteLink);
+                event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER, kickMessage);
+                return;
+            }
+        }
+
         // --- MULTI-ACCOUNT / SHARED IP DETECTION ---
         List<String> otherIds = userManager.getOtherDiscordIdsWithSameIp(ipAddress, discordId);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,13 @@ language: en
 # Note: You can override this for specific users using /dvdecision allow <discordId | playerName> <amount>
 default-max-accounts-per-ip: 1
 
+# The ID of your Discord server (guild). If a player isn't on the server, they won't be allowed in.
+# Leave this field blank ("") to disable this check.
+required-guild-id: ""
+
+# A link to the Discord server invitation that will be displayed to the player if they are not on the server.
+discord-invite-link: "https://discord.gg/yourinvite"
+
 # If configured, multi-account alerts will be sent directly to your Discord staff channel
 discord-alerts:
   channel-id: "" # E.g., "123456789012345678"

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -18,6 +18,7 @@ in-game:
   action-success: "&aAction completed successfully."
   action-failed: "&cFailed to execute action."
   reloaded: "&#14C60D[DiscordVerificator] Reloaded!"
+  not-in-discord-server: "&cYou must be a member of our Discord server to play!\n&fPlease join using this link: &n%s"
 
 discord:
   error-occurred: "An error occurred!"

--- a/src/main/resources/lang/ua.yml
+++ b/src/main/resources/lang/ua.yml
@@ -18,6 +18,7 @@ in-game:
   action-success: "&aДію успішно виконано."
   action-failed: "&cНе вдалося виконати дію."
   reloaded: "&#14C60D[DiscordVerificator] Перезавантажено!"
+  not-in-discord-server: "&cВи повинні бути учасником нашого Discord сервера, щоб грати!\n&fБудь ласка, приєднайтесь за посиланням: &n%s"
 
 discord:
   error-occurred: "Виникла помилка!"


### PR DESCRIPTION
Enforces Discord guild membership for players by adding a configuration option to specify a required guild ID and invite link. This enhancement ensures that players must belong to the specified guild.